### PR TITLE
links zu Resolutionen gefixt, followup on #84

### DIFF
--- a/publikationen/resolutionen/index.md
+++ b/publikationen/resolutionen/index.md
@@ -10,110 +10,110 @@ Hier sind die von den verschiedenen KoMata verabschiedeten Resolutionen zu finde
 
 ## Erlangen
 
-[**83/1: Resolution zu Beratungsgesprächen bei anstehendem letztmöglichen Prüfungsversuch**](https://die-koma.org/wiki-beta/images/f/ff/83_1.pdf)
+[**83/1: Resolution zu Beratungsgesprächen bei anstehendem letztmöglichen Prüfungsversuch**](https://komapedia.org/Spezial:Weiterleitung/file/83_1.pdf)
 
-[**83/2: Resolution gegen die Durchführung von Onlinewahlen an Hochschulen**](https://die-koma.org/wiki-beta/images/d/d3/83_2.pdf)
+[**83/2: Resolution gegen die Durchführung von Onlinewahlen an Hochschulen**](https://komapedia.org/Spezial:Weiterleitung/file/83_2.pdf)
 
-[**83/3: Resolution zur Lehre in Berufungskommission**](https://die-koma.org/wiki-beta/images/3/32/83_3.pdf)
+[**83/3: Resolution zur Lehre in Berufungskommission**](https://komapedia.org/Spezial:Weiterleitung/file/83_3.pdf)
 
 ## Berlin
 
-[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die HRK**](https://die-koma.org/wiki-beta/images/6/62/82_1.pdf)
+[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die HRK**](https://komapedia.org/Spezial:Weiterleitung/file/82_1.pdf)
 
-[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die KMK**](https://die-koma.org/wiki-beta/images/8/80/82_1_5.pdf)
+[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die KMK**](https://komapedia.org/Spezial:Weiterleitung/file/82_1_5.pdf)
 
-[**82/2: Resolution zur Arbeitszeitbelastung studentischer Hilfskräfte**](https://die-koma.org/wiki-beta/images/1/13/82_2.pdf)
+[**82/2: Resolution zur Arbeitszeitbelastung studentischer Hilfskräfte**](https://komapedia.org/Spezial:Weiterleitung/file/82_2.pdf)
 
-[**82/3: Resolution zum Entwurf des Gesetzes zur Änderung des Hochschulgesetzes NRW**](https://die-koma.org/wiki-beta/images/b/b8/82_3.pdf)
+[**82/3: Resolution zum Entwurf des Gesetzes zur Änderung des Hochschulgesetzes NRW**](https://komapedia.org/Spezial:Weiterleitung/file/82_3.pdf)
 
 ## Wien
 
-[**81/1: Resolution zur drittmittelunabhängigen Finanzierung der Lehre**](https://die-koma.org/wiki-beta/images/1/1e/81_1.pdf)
+[**81/1: Resolution zur drittmittelunabhängigen Finanzierung der Lehre**](https://komapedia.org/Spezial:Weiterleitung/file/81_1.pdf)
 
-[**81/2: Forderung der 81. Konferenz der deutschsprachigen Mathematikfachschaften zur bildungspolitischen Ausrichtung der nächsten Legislaturperiode in Bund und Ländern**](https://die-koma.org/wiki-beta/images/5/52/81_2.pdf)
+[**81/2: Forderung der 81. Konferenz der deutschsprachigen Mathematikfachschaften zur bildungspolitischen Ausrichtung der nächsten Legislaturperiode in Bund und Ländern**](https://komapedia.org/Spezial:Weiterleitung/file/81_2.pdf)
 
 ## Regensburg
 
-[**80/1: Aufforderung der studentischen Nominierung für den Akkreditierungsrat zu folgen**](https://die-koma.org/wiki-beta/images/f/f5/80_1.pdf)
+[**80/1: Aufforderung der studentischen Nominierung für den Akkreditierungsrat zu folgen**](https://komapedia.org/Spezial:Weiterleitung/file/80_1.pdf)
 
-[**80/2: Anforderungen an und Beteiligung der Studierenden in Um- und Neubaugremien**](https://die-koma.org/wiki-beta/images/3/30/80_2.pdf)
+[**80/2: Anforderungen an und Beteiligung der Studierenden in Um- und Neubaugremien**](https://komapedia.org/Spezial:Weiterleitung/file/80_2.pdf)
 
-[**80/3: Resolution zur Schaffung permanenter Stellen im wissenschaftlichen Mittelbau**](https://die-koma.org/wiki-beta/images/d/dc/80_3.pdf)
+[**80/3: Resolution zur Schaffung permanenter Stellen im wissenschaftlichen Mittelbau**](https://komapedia.org/Spezial:Weiterleitung/file/80_3.pdf)
 
-[**80/4: Studentische Mitglieder in Prüfungsausschüssen in Bayern**](https://die-koma.org/wiki-beta/images/8/88/80_4.pdf)
+[**80/4: Studentische Mitglieder in Prüfungsausschüssen in Bayern**](https://komapedia.org/Spezial:Weiterleitung/file/80_4.pdf)
 
-[**80/5: Resolution über Studiengebühren**](https://die-koma.org/wiki-beta/images/7/70/80_5.pdf)
+[**80/5: Resolution über Studiengebühren**](https://komapedia.org/Spezial:Weiterleitung/file/80_5.pdf)
 
-[**80/6: VG Wort**](https://die-koma.org/wiki-beta/images/7/73/80_6.pdf)
+[**80/6: VG Wort**](https://komapedia.org/Spezial:Weiterleitung/file/80_6.pdf)
 
-[**80/7: Vorkurse**](https://die-koma.org/wiki-beta/images/7/7d/80_7.pdf)
+[**80/7: Vorkurse**](https://komapedia.org/Spezial:Weiterleitung/file/80_7.pdf)
 
 ## Dortmund
 
-[**79/1: Resolution zum Termin des Beginns der Vorlesungszeit**](https://die-koma.org/wiki-beta/images/a/aa/79_1.pdf)
+[**79/1: Resolution zum Termin des Beginns der Vorlesungszeit**](https://komapedia.org/Spezial:Weiterleitung/file/79_1.pdf)
 
-[**79/2: Resolution zur VG WORT**](https://die-koma.org/wiki-beta/images/3/34/79_2.pdf)
+[**79/2: Resolution zur VG WORT**](https://komapedia.org/Spezial:Weiterleitung/file/79_2.pdf)
 
 
 ## Heidelberg
 
-[**78/1: Resolution zur VG WORT**](https://die-koma.org/wiki-beta/images/7/70/78_1.pdf)
+[**78/1: Resolution zur VG WORT**](https://komapedia.org/Spezial:Weiterleitung/file/78_1.pdf)
 
-[**78/2: Resolution zu Klausureinsichten**](https://die-koma.org/wiki-beta/images/8/88/78_2.pdf)
+[**78/2: Resolution zu Klausureinsichten**](https://komapedia.org/Spezial:Weiterleitung/file/78_2.pdf)
 
-[**78/3: Resolution zu Lernzentren**](https://die-koma.org/wiki-beta/images/3/3c/78_3.pdf)
+[**78/3: Resolution zu Lernzentren**](https://komapedia.org/Spezial:Weiterleitung/file/78_3.pdf)
 
-[**78/4: Resolution zum Zugang Geflohener**](https://die-koma.org/wiki-beta/images/c/cc/78_4.pdf)
+[**78/4: Resolution zum Zugang Geflohener**](https://komapedia.org/Spezial:Weiterleitung/file/78_4.pdf)
 
 
 ## Ilmenau
 
-[**77/1: Resolution gegen Fremdenfeindlichkeit**](https://die-koma.org/wiki-beta/images/0/0b/77_1.pdf)
+[**77/1: Resolution gegen Fremdenfeindlichkeit**](https://komapedia.org/Spezial:Weiterleitung/file/77_1.pdf)
 
-[**77/2: Resolution zur Verwendung von Taschenrechnern in der Schule**](https://die-koma.org/wiki-beta/images/3/32/77_2.pdf)
+[**77/2: Resolution zur Verwendung von Taschenrechnern in der Schule**](https://komapedia.org/Spezial:Weiterleitung/file/77_2.pdf)
 
-[**77/3: Resolution zur Novellierung des Wissenschaftszeitvertragsgesetzes**](https://die-koma.org/wiki-beta/images/e/e2/77_3.pdf)
+[**77/3: Resolution zur Novellierung des Wissenschaftszeitvertragsgesetzes**](https://komapedia.org/Spezial:Weiterleitung/file/77_3.pdf)
 
 
 ## Aachen
 
-[**76/1: Resolution Netzneutralität**](https://die-koma.org/wiki-beta/images/c/cf/76_1.pdf)
+[**76/1: Resolution Netzneutralität**](https://komapedia.org/Spezial:Weiterleitung/file/76_1.pdf)
 
-[**76/2: Resolution zu Prüfungsunfähigkeit und Attesten**](https://die-koma.org/wiki-beta/images/d/d6/76_2.pdf)
+[**76/2: Resolution zu Prüfungsunfähigkeit und Attesten**](https://komapedia.org/Spezial:Weiterleitung/file/76_2.pdf)
 
-[**76/3: Resolution zu Übungskonzepte an Hochschulen**](https://die-koma.org/wiki-beta/images/2/2e/76_3.pdf)
+[**76/3: Resolution zu Übungskonzepte an Hochschulen**](https://komapedia.org/Spezial:Weiterleitung/file/76_3.pdf)
 
 
 ## Berlin
 
-[**74/1: Resolution zum Gesetzesentwurf des Hochschulzukunftsgesetz im Land NRW**](https://die-koma.org/wiki-beta/images/5/58/74_1.pdf)
+[**74/1: Resolution zum Gesetzesentwurf des Hochschulzukunftsgesetz im Land NRW**](https://komapedia.org/Spezial:Weiterleitung/file/74_1.pdf)
 
 
 ## Kiel
 
-[**72/1: Resolution gegen Studiendauerbegrenzungen**](https://die-koma.org/wiki-beta/images/3/3f/72_1.pdf)
+[**72/1: Resolution gegen Studiendauerbegrenzungen**](https://komapedia.org/Spezial:Weiterleitung/file/72_1.pdf)
 
-[**72/2: Resolution gegen das CHE-Hochschulranking**](https://die-koma.org/wiki-beta/images/1/19/72_2.pdf)
+[**72/2: Resolution gegen das CHE-Hochschulranking**](https://komapedia.org/Spezial:Weiterleitung/file/72_2.pdf)
 
 
 ## Wien
 
-[**71/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://die-koma.org/wiki-beta/images/d/df/71_1.pdf)
+[**71/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://komapedia.org/Spezial:Weiterleitung/file/71_1.pdf)
 
 
 ## Bremen
 
-[**69/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://die-koma.org/wiki-beta/images/2/24/69_1.pdf)
+[**69/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://komapedia.org/Spezial:Weiterleitung/file/69_1.pdf)
 
 
 ## Magdeburg
 
-[**67/1: Resolution gegen eine Trennung von Fach- und Lehramtsstudium**](https://die-koma.org/wiki-beta/images/8/8b/67_1.pdf)
+[**67/1: Resolution gegen eine Trennung von Fach- und Lehramtsstudium**](https://komapedia.org/Spezial:Weiterleitung/file/67_1.pdf)
 
 
 ## Graz
 
-[**65/1: Resolution zum Deutschen Qualifikationsrahmen für lebenslanges Lernen**](https://die-koma.org/wiki-beta/images/9/92/65_1.pdf)
+[**65/1: Resolution zum Deutschen Qualifikationsrahmen für lebenslanges Lernen**](https://komapedia.org/Spezial:Weiterleitung/file/65_1.pdf)
 
 
 ## Augsburg
@@ -125,16 +125,16 @@ Hier sind die von den verschiedenen KoMata verabschiedeten Resolutionen zu finde
 
 ## Oldenburg
 
-[**58/1: Resolution zur Verbesserung der Lehrerausbildung im Fach Mathematik**](https://die-koma.org/wiki-beta/images/7/7b/58_1.pdf)
+[**58/1: Resolution zur Verbesserung der Lehrerausbildung im Fach Mathematik**](https://komapedia.org/Spezial:Weiterleitung/file/58_1.pdf)
 
 [**58/2: Resolution - Umfragebogen**](reso_oldenburg_2)	
 
 
 ## Zürich
 
-[**56/1: Resolution Neunummerierung der KoMa**](https://die-koma.org/wiki-beta/images/0/03/56_1.pdf)
+[**56/1: Resolution Neunummerierung der KoMa**](https://komapedia.org/Spezial:Weiterleitung/file/56_1.pdf)
 
-[**56/2: Resolution Lehrproben in Berufungsverfahren**](https://die-koma.org/wiki-beta/images/4/43/56_2.pdf)
+[**56/2: Resolution Lehrproben in Berufungsverfahren**](https://komapedia.org/Spezial:Weiterleitung/file/56_2.pdf)
 
 
 ## Dortmund


### PR DESCRIPTION
Ups, unten aus Gewohnheit englisch.. ist aber eh nur der snippet für das search-replace. 

Hab ein Paar Links vergessen / übersehen. Jetzt sollte das aber alles sein.

Wichtiger Punkt: jetzt habe ich auf die Komapedia geändert. Für die ganzen Links würde auch ein Wechsel von `die-koma.org` zu `old.die-koma.org` funktionieren, könnte man auch machen.

---

in case one wants to do similar ugly work again and don't search-replace over every file, use this snippet: 
```python
from glob import glob
import re
import requests
import os

def scan_file(fp):
    with open(fp, 'r') as fh:
        text = fh.read()
    for link in re.findall('\((http.*?)\)', text):
        resp = requests.get(link)
        if resp.status_code == 200:
            pass
        elif resp.status_code == 404:
            new_try = os.path.join('https://komapedia.org/Spezial:Weiterleitung/file', link.split("/")[-1])
            new_resp = requests.get(new_try)
            if new_resp.status_code == 200:
                text = text.replace(link, new_try)
                print("'{}' (404) -> {} (200)".format(link, new_try))
            else:
                print("'{}' got 404, but no alternative found".format(link))
        else:
            print("weird status code {}: '{}'".format(resp.status_code, link))
    with open(fp, 'w') as fh:
        fh.write(text)
    return text

# for example this directory, needs to be done for each one
for fp in glob('publikationen/**/*.md'):
    print("\nstarted file {}\n{}".format(fp, '-'*79))
    scan_file(fp)
```

results in 

```
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_paderborn_4.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_augsburg_2.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_dortmund_1.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_paderborn_1.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_dortmund_4.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_oldenburg_2.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_chemnitz_1.md
-------------------------------------------------------------------------------
started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/index.md
-------------------------------------------------------------------------------
'https://die-koma.org/wiki-beta/images/f/ff/83_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/83_1.pdf (200)
'https://die-koma.org/wiki-beta/images/d/d3/83_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/83_2.pdf (200)
'https://die-koma.org/wiki-beta/images/3/32/83_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/83_3.pdf (200)
'https://die-koma.org/wiki-beta/images/6/62/82_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/82_1.pdf (200)
'https://die-koma.org/wiki-beta/images/8/80/82_1_5.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/82_1_5.pdf (200)
'https://die-koma.org/wiki-beta/images/1/13/82_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/82_2.pdf (200)
'https://die-koma.org/wiki-beta/images/b/b8/82_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/82_3.pdf (200)
'https://die-koma.org/wiki-beta/images/1/1e/81_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/81_1.pdf (200)
'https://die-koma.org/wiki-beta/images/5/52/81_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/81_2.pdf (200)
'https://die-koma.org/wiki-beta/images/f/f5/80_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_1.pdf (200)
'https://die-koma.org/wiki-beta/images/3/30/80_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_2.pdf (200)
'https://die-koma.org/wiki-beta/images/d/dc/80_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_3.pdf (200)
'https://die-koma.org/wiki-beta/images/8/88/80_4.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_4.pdf (200)
'https://die-koma.org/wiki-beta/images/7/70/80_5.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_5.pdf (200)
'https://die-koma.org/wiki-beta/images/7/73/80_6.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_6.pdf (200)
'https://die-koma.org/wiki-beta/images/7/7d/80_7.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/80_7.pdf (200)
'https://die-koma.org/wiki-beta/images/a/aa/79_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/79_1.pdf (200)
'https://die-koma.org/wiki-beta/images/3/34/79_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/79_2.pdf (200)
'https://die-koma.org/wiki-beta/images/7/70/78_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/78_1.pdf (200)
'https://die-koma.org/wiki-beta/images/8/88/78_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/78_2.pdf (200)
'https://die-koma.org/wiki-beta/images/3/3c/78_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/78_3.pdf (200)
'https://die-koma.org/wiki-beta/images/c/cc/78_4.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/78_4.pdf (200)
'https://die-koma.org/wiki-beta/images/0/0b/77_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/77_1.pdf (200)
'https://die-koma.org/wiki-beta/images/3/32/77_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/77_2.pdf (200)
'https://die-koma.org/wiki-beta/images/e/e2/77_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/77_3.pdf (200)
'https://die-koma.org/wiki-beta/images/c/cf/76_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/76_1.pdf (200)
'https://die-koma.org/wiki-beta/images/d/d6/76_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/76_2.pdf (200)
'https://die-koma.org/wiki-beta/images/2/2e/76_3.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/76_3.pdf (200)
'https://die-koma.org/wiki-beta/images/5/58/74_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/74_1.pdf (200)
'https://die-koma.org/wiki-beta/images/3/3f/72_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/72_1.pdf (200)
'https://die-koma.org/wiki-beta/images/1/19/72_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/72_2.pdf (200)
'https://die-koma.org/wiki-beta/images/d/df/71_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/71_1.pdf (200)
'https://die-koma.org/wiki-beta/images/2/24/69_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/69_1.pdf (200)
'https://die-koma.org/wiki-beta/images/8/8b/67_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/67_1.pdf (200)
'https://die-koma.org/wiki-beta/images/9/92/65_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/65_1.pdf (200)
'https://die-koma.org/wiki-beta/images/7/7b/58_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/58_1.pdf (200)
'https://die-koma.org/wiki-beta/images/0/03/56_1.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/56_1.pdf (200)
'https://die-koma.org/wiki-beta/images/4/43/56_2.pdf' (404) -> https://komapedia.org/Spezial:Weiterleitung/file/56_2.pdf (200)

started file /Users/nico.albers/git/die-koma.org/publikationen/resolutionen/reso_clausthal_1.md
-------------------------------------------------------------------------------

…
…
…
```