### PR TITLE
Use stable file.komapedia.org links

### DIFF
--- a/foerderverein/index.md
+++ b/foerderverein/index.md
@@ -11,7 +11,7 @@ Dieser gemeinnützige Verein zur Förderung der Konferenz der deutschsprachigen 
 Der Verein greift nicht in inhaltliche Belange der KoMa ein.  
 
 ## Satzung
-Die [Satzung](https://komapedia.org/Spezial:Weiterleitung/file/Satzung_verein_090530.pdf) des Fördervereins der KoMa e.V., letzte Änderung KoMa 64.
+Die [Satzung](https://file.komapedia.org/Satzung_verein_090530.pdf) des Fördervereins der KoMa e.V., letzte Änderung KoMa 64.
 
 ## Mitgliedschaft
 
@@ -27,9 +27,9 @@ Hierzu ein Auszug aus der Satzung:
 
 Die Mitgliedsanträge sind an die unter **Kontakt** angegebene Adresse zu richten oder an ein Mitglied des [aktuellen Vorstandes des Fördervereins](https://die-koma.org/foerderverein/vorstaende/)
 
-1. [Beitrittsformular für ordentliche Mitglieder](https://komapedia.org/Spezial:Weiterleitung/file/Beitrittsformular_KoMa_e_V.pdf)  
-2. [Umformungsformular für ordentliche Mitglieder ihren Status in Fördermitglied ändern wollen](https://komapedia.org/Spezial:Weiterleitung/file/Umformungsformular_KoMa_e_V.pdf)  
-3. [Austrittsformular für ordentliche Mitglieder und Fördermitglieder](https://komapedia.org/Spezial:Weiterleitung/file/Austrittsformular_KoMa_e_V.pdf) 
+1. [Beitrittsformular für ordentliche Mitglieder](https://file.komapedia.org/Beitrittsformular_KoMa_e_V.pdf)  
+2. [Umformungsformular für ordentliche Mitglieder ihren Status in Fördermitglied ändern wollen](https://file.komapedia.org/Umformungsformular_KoMa_e_V.pdf)  
+3. [Austrittsformular für ordentliche Mitglieder und Fördermitglieder](https://file.komapedia.org/Austrittsformular_KoMa_e_V.pdf) 
 
 ## Kontakt
 

--- a/publikationen/berufungshandbuch.md
+++ b/publikationen/berufungshandbuch.md
@@ -17,14 +17,14 @@ Im Rahmen des Arbeitskreises wurde 2009 ein Handbuch erarbeitet, welche Studiere
 # Handbuch Download
 
 ## 2. Auflage, Sommersemester 2012
-[bkhandbuch v2.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Bkhandbuch_v2.pdf)
+[bkhandbuch v2.pdf](https://file.komapedia.org/Bkhandbuch_v2.pdf)
 
 ## 1. Auflage, Sommersemester 2009
-[bkhandbuch v1.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Bkhandbuch_v1.pdf)
+[bkhandbuch v1.pdf](https://file.komapedia.org/Bkhandbuch_v1.pdf)
 
 # Vortragsfolien Berufungskommissionen
 
 Vortragsfolien zum Ablauf einer Berufungskommission und der studentischen Mitwirkung in derselbigen.
 
-* [Vortrag AK BK, Tim Haga, KoMa 66](https://komapedia.org/Spezial:Weiterleitung/file/KoMa_66_vortrag_ak_bk.pdf)
-* [Vortrag AK BK, Peter Köß, KoMa 74](https://komapedia.org/Spezial:Weiterleitung/file/KoMa_74_vortrag_ak_bk.pdf)
+* [Vortrag AK BK, Tim Haga, KoMa 66](https://file.komapedia.org/KoMa_66_vortrag_ak_bk.pdf)
+* [Vortrag AK BK, Peter Köß, KoMa 74](https://file.komapedia.org/KoMa_74_vortrag_ak_bk.pdf)

--- a/publikationen/koma-buch/index.md
+++ b/publikationen/koma-buch/index.md
@@ -36,7 +36,7 @@ Das Buch "Die KoMa in den Zeiten des Paulus" gibt Antworten auf diese Fragen. Es
 
 # Download des Buches
 
-Das Buch erhaltet ihr unter [diesem Link](https://komapedia.org/Spezial:Weiterleitung/file/Nico-Hauser_KoMa-Buch.pdf) (18 MB!).
+Das Buch erhaltet ihr unter [diesem Link](https://file.komapedia.org/Nico-Hauser_KoMa-Buch.pdf) (18 MB!).
 
 # Bestellung
 

--- a/publikationen/liederbuch.md
+++ b/publikationen/liederbuch.md
@@ -10,4 +10,4 @@ Traditionell findet auf der KoMa der AK Pella statt. Dieser hat sich der Aufgabe
 
 ## Liederbuch
 
-[Download](https://komapedia.org/Spezial:Weiterleitung/file/KoMa-Liederbuch.pdf) (Stand: 28. Juli 2015)
+[Download](https://file.komapedia.org/KoMa-Liederbuch.pdf) (Stand: 28. Juli 2015)

--- a/publikationen/meine_kleine_uni.md
+++ b/publikationen/meine_kleine_uni.md
@@ -23,11 +23,11 @@ Falls ihr das Spiel in der unveränderten Version von 1992 spielen möchtet, kö
 
 ### Dateien:
 
-* [Anleitung](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Anleitung.pdf)
-* [Spielplan](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Plan.pdf)
-* [Ereigniskärtchen](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Ereignis.pdf)
-* [Punktekärtchen](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Punkte.pdf)
-* [Prüferkärtchen](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Profmak.pdf)
+* [Anleitung](https://file.komapedia.org/Meine_Kleine_Uni_Anleitung.pdf)
+* [Spielplan](https://file.komapedia.org/Meine_Kleine_Uni_Plan.pdf)
+* [Ereigniskärtchen](https://file.komapedia.org/Meine_Kleine_Uni_Ereignis.pdf)
+* [Punktekärtchen](https://file.komapedia.org/Meine_Kleine_Uni_Punkte.pdf)
+* [Prüferkärtchen](https://file.komapedia.org/Meine_Kleine_Uni_Profmak.pdf)
 
 ### Zum Drucken
 
@@ -45,9 +45,9 @@ Diese Versionen könnt ihr dann problemlos ändern und erweitern. In diesem Fall
 
 Ihr bekommt von uns eine Diskette [42], auf der sich alle Files befinden. Den Rest macht ihr dann selber. (Ausdrucken, kopieren, usw.) Falls ihr ein zuverlässiges e-mail-System besitzt, könnten die Files auch per e-mail kommen (Dann ohne Kosten).
 
-[42] [MS-DOS, 3,5''](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Dos.zip)
+[42] [MS-DOS, 3,5''](https://file.komapedia.org/Meine_Kleine_Uni_Dos.zip)
 
-und für [UNIX-Systeme](https://komapedia.org/Spezial:Weiterleitung/file/Meine_Kleine_Uni_Versand.zip)
+und für [UNIX-Systeme](https://file.komapedia.org/Meine_Kleine_Uni_Versand.zip)
 
 ### Version 2
 

--- a/publikationen/minimalstandards.md
+++ b/publikationen/minimalstandards.md
@@ -15,23 +15,23 @@ Die Minimalstandards sind hierbei wörtlich als "minimal" zu verstehen. Sie lief
 ## Veröffentlichungen
 
 ### Version Post KoMa @ Dresden (Sep. 2010)
-[koma-minsanity-2010-09-27.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2010-09-27.pdf)
+[koma-minsanity-2010-09-27.pdf](https://file.komapedia.org/Koma-minsanity-2010-09-27.pdf)
 
 
 ### Version Post KoMa @ Graz (Dez. 2009)
-[koma-minsanity-2009-12-20.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2009-12-20.pdf)
+[koma-minsanity-2009-12-20.pdf](https://file.komapedia.org/Koma-minsanity-2009-12-20.pdf)
 
 ### Version Post KoMa @ Paderborn (Nov. 2008)
-[koma-minsanity-2008-11-16.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2008-11-16.pdf)
+[koma-minsanity-2008-11-16.pdf](https://file.komapedia.org/Koma-minsanity-2008-11-16.pdf)
 
 ### Version Post KoMa @ Chemnitz
-[koma-minsanity-2008-05-26.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2008-05-26.pdf)
+[koma-minsanity-2008-05-26.pdf](https://file.komapedia.org/Koma-minsanity-2008-05-26.pdf)
 
 ### Version Post KoMa @ Regensburg
-[koma-minsanity-2008-03-24.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2008-03-24.pdf)
+[koma-minsanity-2008-03-24.pdf](https://file.komapedia.org/Koma-minsanity-2008-03-24.pdf)
 
 ### Version Post KoMa @ Karlsruhe
-[koma-minsanity-2007-05-23.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2007-05-23.pdf)
+[koma-minsanity-2007-05-23.pdf](https://file.komapedia.org/Koma-minsanity-2007-05-23.pdf)
 
 ### Erster Entwurf
-[koma-minsanity-2007-05-19.pdf](https://komapedia.org/Spezial:Weiterleitung/file/Koma-minsanity-2007-05-19.pdf)
+[koma-minsanity-2007-05-19.pdf](https://file.komapedia.org/Koma-minsanity-2007-05-19.pdf)

--- a/publikationen/neulingsheft.md
+++ b/publikationen/neulingsheft.md
@@ -10,4 +10,4 @@ Wer zum ersten Mal auf einer KoMa ist oder noch nie da war, für den ist es sich
 
 ## Download
 
-Das Heft gibt es entweder gedruckt auf der nächsten KoMa oder [hier als Datei](https://komapedia.org/Spezial:Weiterleitung/file/Neulingsheft.pdf) (Stand: Frühjahr 2012).
+Das Heft gibt es entweder gedruckt auf der nächsten KoMa oder [hier als Datei](https://file.komapedia.org/Neulingsheft.pdf) (Stand: Frühjahr 2012).

--- a/publikationen/resolutionen/index.md
+++ b/publikationen/resolutionen/index.md
@@ -10,110 +10,110 @@ Hier sind die von den verschiedenen KoMata verabschiedeten Resolutionen zu finde
 
 ## Erlangen
 
-[**83/1: Resolution zu Beratungsgesprächen bei anstehendem letztmöglichen Prüfungsversuch**](https://komapedia.org/Spezial:Weiterleitung/file/83_1.pdf)
+[**83/1: Resolution zu Beratungsgesprächen bei anstehendem letztmöglichen Prüfungsversuch**](https://file.komapedia.org/83_1.pdf)
 
-[**83/2: Resolution gegen die Durchführung von Onlinewahlen an Hochschulen**](https://komapedia.org/Spezial:Weiterleitung/file/83_2.pdf)
+[**83/2: Resolution gegen die Durchführung von Onlinewahlen an Hochschulen**](https://file.komapedia.org/83_2.pdf)
 
-[**83/3: Resolution zur Lehre in Berufungskommission**](https://komapedia.org/Spezial:Weiterleitung/file/83_3.pdf)
+[**83/3: Resolution zur Lehre in Berufungskommission**](https://file.komapedia.org/83_3.pdf)
 
 ## Berlin
 
-[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die HRK**](https://komapedia.org/Spezial:Weiterleitung/file/82_1.pdf)
+[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die HRK**](https://file.komapedia.org/82_1.pdf)
 
-[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die KMK**](https://komapedia.org/Spezial:Weiterleitung/file/82_1_5.pdf)
+[**82/1: Resolution zu Arbeitsrechtsbelehrungen studentischer Hilfskräfte an die KMK**](https://file.komapedia.org/82_1_5.pdf)
 
-[**82/2: Resolution zur Arbeitszeitbelastung studentischer Hilfskräfte**](https://komapedia.org/Spezial:Weiterleitung/file/82_2.pdf)
+[**82/2: Resolution zur Arbeitszeitbelastung studentischer Hilfskräfte**](https://file.komapedia.org/82_2.pdf)
 
-[**82/3: Resolution zum Entwurf des Gesetzes zur Änderung des Hochschulgesetzes NRW**](https://komapedia.org/Spezial:Weiterleitung/file/82_3.pdf)
+[**82/3: Resolution zum Entwurf des Gesetzes zur Änderung des Hochschulgesetzes NRW**](https://file.komapedia.org/82_3.pdf)
 
 ## Wien
 
-[**81/1: Resolution zur drittmittelunabhängigen Finanzierung der Lehre**](https://komapedia.org/Spezial:Weiterleitung/file/81_1.pdf)
+[**81/1: Resolution zur drittmittelunabhängigen Finanzierung der Lehre**](https://file.komapedia.org/81_1.pdf)
 
-[**81/2: Forderung der 81. Konferenz der deutschsprachigen Mathematikfachschaften zur bildungspolitischen Ausrichtung der nächsten Legislaturperiode in Bund und Ländern**](https://komapedia.org/Spezial:Weiterleitung/file/81_2.pdf)
+[**81/2: Forderung der 81. Konferenz der deutschsprachigen Mathematikfachschaften zur bildungspolitischen Ausrichtung der nächsten Legislaturperiode in Bund und Ländern**](https://file.komapedia.org/81_2.pdf)
 
 ## Regensburg
 
-[**80/1: Aufforderung der studentischen Nominierung für den Akkreditierungsrat zu folgen**](https://komapedia.org/Spezial:Weiterleitung/file/80_1.pdf)
+[**80/1: Aufforderung der studentischen Nominierung für den Akkreditierungsrat zu folgen**](https://file.komapedia.org/80_1.pdf)
 
-[**80/2: Anforderungen an und Beteiligung der Studierenden in Um- und Neubaugremien**](https://komapedia.org/Spezial:Weiterleitung/file/80_2.pdf)
+[**80/2: Anforderungen an und Beteiligung der Studierenden in Um- und Neubaugremien**](https://file.komapedia.org/80_2.pdf)
 
-[**80/3: Resolution zur Schaffung permanenter Stellen im wissenschaftlichen Mittelbau**](https://komapedia.org/Spezial:Weiterleitung/file/80_3.pdf)
+[**80/3: Resolution zur Schaffung permanenter Stellen im wissenschaftlichen Mittelbau**](https://file.komapedia.org/80_3.pdf)
 
-[**80/4: Studentische Mitglieder in Prüfungsausschüssen in Bayern**](https://komapedia.org/Spezial:Weiterleitung/file/80_4.pdf)
+[**80/4: Studentische Mitglieder in Prüfungsausschüssen in Bayern**](https://file.komapedia.org/80_4.pdf)
 
-[**80/5: Resolution über Studiengebühren**](https://komapedia.org/Spezial:Weiterleitung/file/80_5.pdf)
+[**80/5: Resolution über Studiengebühren**](https://file.komapedia.org/80_5.pdf)
 
-[**80/6: VG Wort**](https://komapedia.org/Spezial:Weiterleitung/file/80_6.pdf)
+[**80/6: VG Wort**](https://file.komapedia.org/80_6.pdf)
 
-[**80/7: Vorkurse**](https://komapedia.org/Spezial:Weiterleitung/file/80_7.pdf)
+[**80/7: Vorkurse**](https://file.komapedia.org/80_7.pdf)
 
 ## Dortmund
 
-[**79/1: Resolution zum Termin des Beginns der Vorlesungszeit**](https://komapedia.org/Spezial:Weiterleitung/file/79_1.pdf)
+[**79/1: Resolution zum Termin des Beginns der Vorlesungszeit**](https://file.komapedia.org/79_1.pdf)
 
-[**79/2: Resolution zur VG WORT**](https://komapedia.org/Spezial:Weiterleitung/file/79_2.pdf)
+[**79/2: Resolution zur VG WORT**](https://file.komapedia.org/79_2.pdf)
 
 
 ## Heidelberg
 
-[**78/1: Resolution zur VG WORT**](https://komapedia.org/Spezial:Weiterleitung/file/78_1.pdf)
+[**78/1: Resolution zur VG WORT**](https://file.komapedia.org/78_1.pdf)
 
-[**78/2: Resolution zu Klausureinsichten**](https://komapedia.org/Spezial:Weiterleitung/file/78_2.pdf)
+[**78/2: Resolution zu Klausureinsichten**](https://file.komapedia.org/78_2.pdf)
 
-[**78/3: Resolution zu Lernzentren**](https://komapedia.org/Spezial:Weiterleitung/file/78_3.pdf)
+[**78/3: Resolution zu Lernzentren**](https://file.komapedia.org/78_3.pdf)
 
-[**78/4: Resolution zum Zugang Geflohener**](https://komapedia.org/Spezial:Weiterleitung/file/78_4.pdf)
+[**78/4: Resolution zum Zugang Geflohener**](https://file.komapedia.org/78_4.pdf)
 
 
 ## Ilmenau
 
-[**77/1: Resolution gegen Fremdenfeindlichkeit**](https://komapedia.org/Spezial:Weiterleitung/file/77_1.pdf)
+[**77/1: Resolution gegen Fremdenfeindlichkeit**](https://file.komapedia.org/77_1.pdf)
 
-[**77/2: Resolution zur Verwendung von Taschenrechnern in der Schule**](https://komapedia.org/Spezial:Weiterleitung/file/77_2.pdf)
+[**77/2: Resolution zur Verwendung von Taschenrechnern in der Schule**](https://file.komapedia.org/77_2.pdf)
 
-[**77/3: Resolution zur Novellierung des Wissenschaftszeitvertragsgesetzes**](https://komapedia.org/Spezial:Weiterleitung/file/77_3.pdf)
+[**77/3: Resolution zur Novellierung des Wissenschaftszeitvertragsgesetzes**](https://file.komapedia.org/77_3.pdf)
 
 
 ## Aachen
 
-[**76/1: Resolution Netzneutralität**](https://komapedia.org/Spezial:Weiterleitung/file/76_1.pdf)
+[**76/1: Resolution Netzneutralität**](https://file.komapedia.org/76_1.pdf)
 
-[**76/2: Resolution zu Prüfungsunfähigkeit und Attesten**](https://komapedia.org/Spezial:Weiterleitung/file/76_2.pdf)
+[**76/2: Resolution zu Prüfungsunfähigkeit und Attesten**](https://file.komapedia.org/76_2.pdf)
 
-[**76/3: Resolution zu Übungskonzepte an Hochschulen**](https://komapedia.org/Spezial:Weiterleitung/file/76_3.pdf)
+[**76/3: Resolution zu Übungskonzepte an Hochschulen**](https://file.komapedia.org/76_3.pdf)
 
 
 ## Berlin
 
-[**74/1: Resolution zum Gesetzesentwurf des Hochschulzukunftsgesetz im Land NRW**](https://komapedia.org/Spezial:Weiterleitung/file/74_1.pdf)
+[**74/1: Resolution zum Gesetzesentwurf des Hochschulzukunftsgesetz im Land NRW**](https://file.komapedia.org/74_1.pdf)
 
 
 ## Kiel
 
-[**72/1: Resolution gegen Studiendauerbegrenzungen**](https://komapedia.org/Spezial:Weiterleitung/file/72_1.pdf)
+[**72/1: Resolution gegen Studiendauerbegrenzungen**](https://file.komapedia.org/72_1.pdf)
 
-[**72/2: Resolution gegen das CHE-Hochschulranking**](https://komapedia.org/Spezial:Weiterleitung/file/72_2.pdf)
+[**72/2: Resolution gegen das CHE-Hochschulranking**](https://file.komapedia.org/72_2.pdf)
 
 
 ## Wien
 
-[**71/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://komapedia.org/Spezial:Weiterleitung/file/71_1.pdf)
+[**71/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://file.komapedia.org/71_1.pdf)
 
 
 ## Bremen
 
-[**69/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://komapedia.org/Spezial:Weiterleitung/file/69_1.pdf)
+[**69/1: Resolution zur Tutorensuche und -auswahl in mathematischen Studiengängen**](https://file.komapedia.org/69_1.pdf)
 
 
 ## Magdeburg
 
-[**67/1: Resolution gegen eine Trennung von Fach- und Lehramtsstudium**](https://komapedia.org/Spezial:Weiterleitung/file/67_1.pdf)
+[**67/1: Resolution gegen eine Trennung von Fach- und Lehramtsstudium**](https://file.komapedia.org/67_1.pdf)
 
 
 ## Graz
 
-[**65/1: Resolution zum Deutschen Qualifikationsrahmen für lebenslanges Lernen**](https://komapedia.org/Spezial:Weiterleitung/file/65_1.pdf)
+[**65/1: Resolution zum Deutschen Qualifikationsrahmen für lebenslanges Lernen**](https://file.komapedia.org/65_1.pdf)
 
 
 ## Augsburg
@@ -125,16 +125,16 @@ Hier sind die von den verschiedenen KoMata verabschiedeten Resolutionen zu finde
 
 ## Oldenburg
 
-[**58/1: Resolution zur Verbesserung der Lehrerausbildung im Fach Mathematik**](https://komapedia.org/Spezial:Weiterleitung/file/58_1.pdf)
+[**58/1: Resolution zur Verbesserung der Lehrerausbildung im Fach Mathematik**](https://file.komapedia.org/58_1.pdf)
 
 [**58/2: Resolution - Umfragebogen**](reso_oldenburg_2)	
 
 
 ## Zürich
 
-[**56/1: Resolution Neunummerierung der KoMa**](https://komapedia.org/Spezial:Weiterleitung/file/56_1.pdf)
+[**56/1: Resolution Neunummerierung der KoMa**](https://file.komapedia.org/56_1.pdf)
 
-[**56/2: Resolution Lehrproben in Berufungsverfahren**](https://komapedia.org/Spezial:Weiterleitung/file/56_2.pdf)
+[**56/2: Resolution Lehrproben in Berufungsverfahren**](https://file.komapedia.org/56_2.pdf)
 
 
 ## Dortmund


### PR DESCRIPTION
This allows us to have the redirects still point at the old wiki while
we're busy moving to the new wiki; it also allows for more flexibility,
should we decide to move somewhere else.

Signed-off-by: Maximilian Marx <maximilian.marx@tu-dresden.de>