### PR TITLE
Github action to sync a `next-koma.json` from the wiki

### DIFF
--- a/.github/workflows/update-next-koma.yml
+++ b/.github/workflows/update-next-koma.yml
@@ -1,0 +1,38 @@
+name: "Update next-koma.json"
+
+on:
+  schedule:
+    - cron: '0 8,20 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  update-next-koma:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download raw json from the wiki
+        run: curl -o next-koma-raw.json --globoff "https://de.komapedia.org/api.php?origin=*&action=ask&format=json&query=[[Category:KoMa]][[ende::%3E$(date -I)]]|sort=KoMaNr|order=asc|limit=5|?Ort|?Beginn|?Ende"
+
+      - name: Preprocess json results
+        run: |
+          jq .query.results <next-koma-raw.json >next-koma.json
+          rm next-koma-raw.json
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Sync next-koma.json from wiki
+          branch: update-next-koma-json
+          delete-branch: true
+          title: 'Update next-koma.json'
+          body: |
+            This is an automatically created PR.
+
+            The contents of `next-koma.json` was taken from the wiki.
+          labels: |
+            automated pr


### PR DESCRIPTION
This adds a github action to sync a new json file about the next koma events from the wiki into the root of this repo. The action can be run manually and is also triggered on a schedule two times a day. It creates a PR only, if there are changes to the file and will update an already existing PR if possible.

The json file can be used to derive the next-koma block on the website.