### PR TITLE
Easier build-instructions for Windows, without WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,26 +50,4 @@ Likely the same as above, but use `homebrew` instead of `apt`?
 
 
 ## Windows
-You've lost the game anyways, perhaps try WSL2 with nix?
-
-## Windows with WSL Ubuntu
-### Cloning and Installation (run once)
-```sh
-# clone "die-koma.org" to a directory without any spaces!
-cd die-koma.org
-# start wsl in the directory
-
-sudo apt install nodejs npm  # install nodejs and packages
-```
-
-### Serving the Website locally
-```sh
-cd die-koma.org
-# start wsl in the directory
-
-git pull  # make sure to be on main, pull latest version :)
-npm install  # install js dependencies of this project
-npm run dev  # start development server
-
-# open http://localhost:4321/ in a browser (either host or within wsl)
-```
+You can use WSL, or [install `npm`](https://nodejs.org/en/download) and then use the above steps (skipping `sudo apt install nodejs npm`).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ nix run
 ```sh
 # ruby installation stuff:
 sudo apt install nodejs npm
+
 cd "die-koma.org"
 git pull  # make sure to be on main, pull latest version :)
 npm install  # install dependencies
@@ -50,4 +51,4 @@ Likely the same as above, but use `homebrew` instead of `apt`?
 
 
 ## Windows
-You can use WSL, or [install `npm`](https://nodejs.org/en/download) and then use the above steps (skipping `sudo apt install nodejs npm`).
+First [install `npm`](https://nodejs.org/en/download) and then use the above steps, skipping `sudo apt install nodejs npm`. You can also use WSL.

--- a/README.md
+++ b/README.md
@@ -34,21 +34,19 @@ nix run .#install
 nix run
 ```
 
+## Debian/Ubuntu, MacOS, Windows
 
-## Debian/Ubuntu
+First install `npm`:
+
+- Debian/Ubuntu or WSL: `sudo apt install nodejs npm`
+- MacOS: `brew install npm`
+- Windows: `winget install -e --id OpenJS.NodeJS && echo you lost the game`
+
+And then:
+
 ```sh
-# ruby installation stuff:
-sudo apt install nodejs npm
-
 cd "die-koma.org"
-git pull  # make sure to be on main, pull latest version :)
+git pull     # make sure to be on main, pull latest version :)
 npm install  # install dependencies
 npm run dev  # start development server
 ```
-
-## MacOS
-Likely the same as above, but use `homebrew` instead of `apt`?
-
-
-## Windows
-[Install `npm`](https://nodejs.org/en/download) and then use the above steps, replacing `sudo apt install nodejs npm` with `echo you lost the game`. Alternatively, use WSL.

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Likely the same as above, but use `homebrew` instead of `apt`?
 
 
 ## Windows
-First [install `npm`](https://nodejs.org/en/download) and then use the above steps, skipping `sudo apt install nodejs npm`. You can also use WSL.
+[Install `npm`](https://nodejs.org/en/download) and then use the above steps, replacing `sudo apt install nodejs npm` with `echo you lost the game`. Alternatively, use WSL.


### PR DESCRIPTION
Currently, the README's installation-instructions for Windows only specify WSL. However, `npm` is available on Windows without WSL, and can be used normally: I tried `npm run dev`, and everything seemed to work as expected. My node-version is 22.13.1, npm-version is 11.3.0. If there are any integration- or unit-tests I should run, let me know.

This PR updates the build-instructions in the README appropriately.

The build-instructions for Debian/Ubuntu, MacOS, Windows are now nearly-identical, they only differ in the way they install `npm`. Maybe one could write the README more cleanly in that regard, but I didn't want to edit too much in this PR.